### PR TITLE
Adding explicit styles for a.zocial:visited and a.zocial:hover...

### DIFF
--- a/css/zocial.css
+++ b/css/zocial.css
@@ -23,7 +23,7 @@ Enjoy
 /* Button structure */
 
 .zocial,
-a.zocial {
+a.zocial, a.zocial:visited, a.zocial:hover {
 	border: 1px solid #777;
 	border-color: rgba(0,0,0,0.2);
 	border-bottom-color: #333;


### PR DESCRIPTION
I noticed that if you have styles defined for `a:visited` and/or `a:hover`, these styles will override the zocial styles if you're using an anchor tag with zocial. So, I added the selectors: `a.zocial:visited` and `a.zocial:hover` to the main `.zocial` selector to prevent this from happening.
